### PR TITLE
[검색페이지] 검색페이지 뷰 생성

### DIFF
--- a/src/assets/svg/IcBack.tsx
+++ b/src/assets/svg/IcBack.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+
+const IcBack = () => (<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon/back" clip-path="url(#clip0_47_7264)">
+<path id="Vector 1 (Stroke)" fill-rule="evenodd" clip-rule="evenodd" d="M6.82703 12.9996L12.414 18.5864L11.0003 20L3 12L11.0003 4L12.414 5.41365L6.82703 11.0004L21 11.0004V12.9996L6.82703 12.9996Z" fill="#27262E"/>
+</g>
+<defs>
+<clipPath id="clip0_47_7264">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>);
+
+export default IcBack;

--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -13,3 +13,4 @@ export { default as IcTitleIcon } from './IcTitleIcon';
 export { default as IcKakaoButton } from './IcKakaoButton';
 export { default as IcPlus } from './IcPlus.tsx';
 export { default as IcCheck } from './IcCheck.tsx';
+export { default as IcBack } from './IcBack.tsx';

--- a/src/components/Friend/FriendItem/FriendItem.style.ts
+++ b/src/components/Friend/FriendItem/FriendItem.style.ts
@@ -25,8 +25,4 @@ export const NicknameBox = styled.div`
   ${({ theme }) => theme.fonts.sb_13_600};
   width: 22.7rem;
   height: 3.5rem;
-  p {
-    ${({ theme }) => theme.fonts.m_11_400};
-    color: ${({ theme }) => theme.colors.gray[500]};
-  }
 `;

--- a/src/components/Friend/FriendItem/FriendItem.tsx
+++ b/src/components/Friend/FriendItem/FriendItem.tsx
@@ -21,7 +21,6 @@ const FriendItem = ({ children }: FriendItemProps) => {
       <S.FriendImg src={profileMockImage}/>
       <S.NicknameBox>
         {children}
-        <p>새로 가입한 또래친구</p>
       </S.NicknameBox>
       {
         !isClick ? <IcPlus /> : <IcCheck />

--- a/src/components/Search/Search.style.ts
+++ b/src/components/Search/Search.style.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const SearchWrapper = styled.div`
+${({ theme: { mixin } }) => mixin.flexBox({ direction:'column', align: 'center' })};
+width: 100%;
+padding: 1.4rem 1.6rem 0 1.6rem;
+gap: 2rem;
+`;
+
+export const BackButton = styled.button`
+background-color: white;
+`;
+
+export const BarWrapper = styled.div`
+width: 100%;
+display: flex;
+align-items: center;
+height: fit-content;
+gap: 1.2rem;
+`;

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import * as S from './Search.style';
+import SearchingBar from "./SearchingBar/SearchingBar";
+import { IcBack } from "../../assets/svg";
+import { useNavigate } from "react-router-dom";
+import SearchNone from "./SearchNone/SearchNone";
+import SearchPerson from "./SearchPerson/SearchPerson";
+
+const Search = () => {
+    const navigate = useNavigate();
+    const nickName = "이웃집 영자";
+    const [nickname,setNickname] = useState("");
+    const handleInputChange = (value:string) => {
+        setNickname(value);
+    };
+    return (
+        <S.SearchWrapper>
+            <S.BarWrapper>
+            <S.BackButton onClick={()=> navigate(-1)}>
+                <IcBack />
+            </S.BackButton>
+            <SearchingBar value={nickname} onChange={handleInputChange}/>
+            </S.BarWrapper>
+            {nickname 
+                ? (nickName === nickname ? <SearchPerson/> : <SearchNone/>) 
+                : null}
+        </S.SearchWrapper>
+    )
+}
+
+export default Search;

--- a/src/components/Search/SearchNone/SearchNone.style.ts
+++ b/src/components/Search/SearchNone/SearchNone.style.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const SearchNoneWrapper = styled.div`
+display: flex;
+width: 100%;
+height: 100%;
+background-color: white;
+`;
+
+export const TextWrapper = styled.div`
+${({ theme: { mixin } }) => mixin.flexCenter({direction: 'column',algin: 'center'})};
+background-color: white;
+width:100%;
+height: fit-content;
+padding: 4.4rem 0;
+gap: 0.5rem;
+${({ theme }) => theme.fonts.m_14_500};
+color: ${({ theme }) => theme.colors.gray[600]};
+`;

--- a/src/components/Search/SearchNone/SearchNone.tsx
+++ b/src/components/Search/SearchNone/SearchNone.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import * as S from './SearchNone.style';
+
+const SearchNone = () => {
+    return (
+        <S.SearchNoneWrapper>
+            <S.TextWrapper>
+            <div>해당 닉네임과 동일한</div>친구를 찾지 못했습니다.
+            </S.TextWrapper>
+        </S.SearchNoneWrapper>
+    )
+}
+
+export default SearchNone;

--- a/src/components/Search/SearchPerson/SearchPerson.style.ts
+++ b/src/components/Search/SearchPerson/SearchPerson.style.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const SearchPersonWrapper = styled.div`
+${({ theme: { mixin } }) => mixin.flexBox({direction: 'column', align:'center'})};
+width: 100%;
+height: 100%;
+background-color: white;
+gap: 0.8rem;
+`;

--- a/src/components/Search/SearchPerson/SearchPerson.tsx
+++ b/src/components/Search/SearchPerson/SearchPerson.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import * as S from './SearchPerson.style';
+import FriendItem from "../../Friend/FriendItem/FriendItem";
+
+const SearchPerson = () => {
+    return (
+        <S.SearchPersonWrapper>
+            <FriendItem>이웃집 영자</FriendItem>
+            <FriendItem>이웃집 영자</FriendItem>
+        </S.SearchPersonWrapper>
+    )
+}
+
+export default SearchPerson;

--- a/src/components/Search/SearchingBar/SearchingBar.style.ts
+++ b/src/components/Search/SearchingBar/SearchingBar.style.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const SearchingBarWrapper = styled.div`
+display: flex;
+align-items: center;
+width: 30.7rem;
+height: 3.8rem;
+padding: 0 1.2rem;
+gap: 0.6rem;
+border-radius: 10px;
+border: 1.2px solid var(--Primary-default, #FF5B29);
+box-shadow: 0px 0px 0px 1px rgba(255, 91, 41, 0.25), 0px 0px 0px 4px rgba(255, 91, 41, 0.10);
+`;
+export const SearchingBarInput = styled.input`
+color: ${({ theme }) => theme.colors.gray[500]};
+${({ theme }) => theme.fonts.m_14_500};
+border: none;
+`;

--- a/src/components/Search/SearchingBar/SearchingBar.tsx
+++ b/src/components/Search/SearchingBar/SearchingBar.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import * as S from './SearchingBar.style';
+import { IcSearch } from "../../../assets/svg";
+
+type SearchingBarProps = {
+    value: string;
+    onChange: (value: string) => void;
+};
+
+const SearchingBar: React.FC<SearchingBarProps> = ({ value, onChange }) => {
+    const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+        onChange(e.target.value);
+    };
+    return (
+        <S.SearchingBarWrapper><IcSearch/><S.SearchingBarInput placeholder="닉네임으로 친구찾기"  value={value}
+        onChange={handleInput}/></S.SearchingBarWrapper>
+    )
+}
+
+export default SearchingBar;

--- a/src/pages/Feed/Feed.style.ts
+++ b/src/pages/Feed/Feed.style.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const FeedWrapper = styled.div`
-${({ theme: { mixin } }) => mixin.flexCenter({ })};
+display: flex;
 ${({ theme }) => theme.fonts.m_30_500};
     color: ${({ theme }) => theme.colors.gray[700]};
     width: 100%;

--- a/src/pages/Feed/Feed.tsx
+++ b/src/pages/Feed/Feed.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import * as S from './Feed.style';
+import Search from '../../components/Search/Search';
 
 const Feed = () => {
     return (
-        <S.FeedWrapper> 피드 페이지 입니다.</S.FeedWrapper>
+        <S.FeedWrapper> <Search/>피드 페이지 입니다.</S.FeedWrapper>
     )
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #29 

## 🪄작업 내용
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
>뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 검색 페이지 컴포넌트와 뷰를 피드 페이지 상단부분에 생성하였습니다.

https://github.com/user-attachments/assets/dd65c272-3265-4a9d-aaa9-caf5211eedc3




## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.


- api 연결 해보면서 data 부분을 확정 시킬거 같네요,, 확실히 이렇게 api 가 늦어지는 경우에는 mock api 사용이 필요하다는 생각이 많이 들어요!
- 친구 페이지로 넘어가는 부분도 공통컴포넌트로 friend list 를 조금 수정해야할거 같아요 !!!
뭔가 체크 하는 기능 외에도, 체크 버튼이 아닌 아이콘을 누르면 넘어갈 수 있게끔 !!!! 해야할거 같습니다. 
뷰적인게 똑같은데 다른 기능을 한다면 공통컴포넌트로 제작할 수 있다고 생각해요 !!
=> 해당 부분은 친구 페이지 만들 때 제가 같이 작업해보겠습니다!
- 해당 작업을 마무리 한 후, 피드 작업을 연결해서 할 예정입니다 ! 피드 부분도 내일까지 후다닥 해볼게요 !! merge 할 수 있도록 리뷰 해주시면 감사드리겠습니다!!
아마도 뷰 관련 부분이어서 많이 거창하지 않을거에요 !!
